### PR TITLE
fix: pass OLLAMA_HOST to Ollama JS client constructor

### DIFF
--- a/src/core/embeddings.ts
+++ b/src/core/embeddings.ts
@@ -64,7 +64,7 @@ const MIN_EMBED_BATCH_SIZE = 5;
 const MAX_EMBED_BATCH_SIZE = 10;
 const DEFAULT_EMBED_BATCH_SIZE = 8;
 
-const ollama = new Ollama();
+const ollama = new Ollama({ host: process.env.OLLAMA_HOST });
 
 function toIntegerOr(value: string | undefined, fallback: number): number {
   if (!value) return fallback;

--- a/src/tools/semantic-navigate.ts
+++ b/src/tools/semantic-navigate.ts
@@ -32,7 +32,7 @@ const EMBED_MODEL = process.env.OLLAMA_EMBED_MODEL ?? "nomic-embed-text";
 const CHAT_MODEL = process.env.OLLAMA_CHAT_MODEL ?? "llama3.2";
 const MAX_FILES_PER_LEAF = 20;
 
-const ollama = new Ollama();
+const ollama = new Ollama({ host: process.env.OLLAMA_HOST });
 
 async function fetchEmbeddings(inputs: string[]): Promise<number[][]> {
   return fetchEmbedding(inputs);


### PR DESCRIPTION
Pass process.env.OLLAMA_HOST to the Ollama constructor in src/core/embeddings.ts and src/tools/semantic-navigate.ts.

Fixes #3
