### PR TITLE
Fix: pre-truncate oversized embedding input to prevent SDK hang

### DIFF
--- a/src/core/embeddings.ts
+++ b/src/core/embeddings.ts
@@ -66,6 +66,7 @@ const DEFAULT_EMBED_BATCH_SIZE = 8;
 const MIN_EMBED_INPUT_CHARS = 256;
 const SINGLE_INPUT_SHRINK_FACTOR = 0.75;
 const MAX_SINGLE_INPUT_RETRIES = 8;
+const MAX_EMBED_INPUT_CHARS = 8000; // Conservative limit to avoid Ollama SDK hanging on oversized input
 
 const ollama = new Ollama({ host: process.env.OLLAMA_HOST });
 
@@ -293,7 +294,8 @@ export class SearchIndex {
 
     for (let i = 0; i < docs.length; i++) {
       const doc = docs[i];
-      const text = `${doc.header} ${doc.symbols.join(" ")} ${doc.content}`;
+      const rawText = `${doc.header} ${doc.symbols.join(" ")} ${doc.content}`;
+      const text = rawText.length > MAX_EMBED_INPUT_CHARS ? rawText.slice(0, MAX_EMBED_INPUT_CHARS) : rawText;
       const hash = hashContent(text);
 
       if (cache[doc.path]?.hash === hash) {


### PR DESCRIPTION
## Problem

The Ollama JS SDK **hangs indefinitely** (promise never resolves or rejects) when embedding input exceeds the model's context window (e.g. `nomic-embed-text` at 8192 tokens). 

This means `embedSingleAdaptive`'s retry logic never fires — no error is thrown, so `isContextLengthError` is never checked. The result is `semantic_code_search` failing with "Unable to embed oversized input after adaptive retries" for any project with large files.

## Root Cause

Ollama server returns HTTP 400 with `"the input length exceeds the context length"`, but the JS SDK (`ollama@^0.6.3`) doesn't surface this as a rejected promise — it hangs.

## Reproduction

Any project containing large generated or auto-generated files (codegen output, type declarations, migration snapshots, etc.) triggers this. The text assembled at `SearchIndex.index()` (`header + symbols + content`) for these files far exceeds the model's context window.

## Fix

Pre-truncate input text to **8000 chars** before calling `ollama.embed()`. This is conservative for `nomic-embed-text`'s 8192 token context. Truncation at index time preserves file headers and symbol names (most semantically relevant) while trimming excess file content.

## Verification

Tested locally against a monorepo with generated files up to 2MB. Before fix: hangs/errors. After fix: indexes and searches correctly.