### PR TITLE
fix: prevent CWE-78 command injection in static analysis runner

### DIFF
--- a/src/tools/static-analysis.ts
+++ b/src/tools/static-analysis.ts
@@ -1,12 +1,12 @@
 // Static analysis runner using native linters and compilers
 // Delegates dead code detection to deterministic tools, not LLM guessing
 
-import { exec } from "child_process";
+import { execFile } from "child_process";
 import { stat } from "fs/promises";
 import { resolve, extname } from "path";
 import { promisify } from "util";
 
-const execAsync = promisify(exec);
+const execFileAsync = promisify(execFile);
 
 export interface StaticAnalysisOptions {
   rootDir: string;
@@ -29,9 +29,8 @@ const LINTER_MAP: Record<string, { cmd: string; args: string[] }> = {
 };
 
 async function runCommand(cmd: string, args: string[], cwd: string): Promise<LintResult> {
-  const fullCmd = `${cmd} ${args.join(" ")}`;
   try {
-    const { stdout, stderr } = await execAsync(fullCmd, { cwd, timeout: 30000, maxBuffer: 1024 * 512 });
+    const { stdout, stderr } = await execFileAsync(cmd, args, { cwd, timeout: 30000, maxBuffer: 1024 * 512 });
     return { tool: cmd, output: (stdout + stderr).trim(), exitCode: 0 };
   } catch (err: any) {
     return { tool: cmd, output: (err.stdout ?? "") + (err.stderr ?? ""), exitCode: err.code ?? 1 };

--- a/test/main/static-analysis-injection.test.mjs
+++ b/test/main/static-analysis-injection.test.mjs
@@ -1,0 +1,102 @@
+// Test: CWE-78 command injection via targetPath in static analysis
+// Verifies that shell metacharacters in targetPath cannot be used for injection
+
+import { describe, it, before, after } from "node:test";
+import assert from "node:assert";
+import { mkdir, writeFile, rm, readFile } from "fs/promises";
+import { resolve, join } from "path";
+
+const { runStaticAnalysis } =
+  await import("../../build/tools/static-analysis.js");
+
+const FIXTURE = resolve("test/_injection_fixtures");
+const SENTINEL = join(FIXTURE, "pwned.txt");
+
+before(async () => {
+  await mkdir(FIXTURE, { recursive: true });
+  await writeFile(
+    join(FIXTURE, "safe.py"),
+    "# Safe python file\n# FEATURE: test\nprint('hello')\n",
+  );
+});
+
+after(async () => {
+  await rm(FIXTURE, { recursive: true, force: true });
+});
+
+describe("CWE-78: command injection via targetPath", () => {
+  it("should not execute injected commands via $() with .py extension", async () => {
+    // This payload ends in .py so it matches the Python linter
+    // The $() will be interpreted by the shell in exec()
+    const maliciousPath = `$(echo INJECTED > ${SENTINEL}).py`;
+    try {
+      await runStaticAnalysis({ rootDir: FIXTURE, targetPath: maliciousPath });
+    } catch {
+      // errors are acceptable – injection must not succeed
+    }
+
+    let injected = false;
+    try {
+      await readFile(SENTINEL, "utf-8");
+      injected = true;
+    } catch {
+      injected = false;
+    }
+    assert.strictEqual(injected, false, "Command injection via $() succeeded – sentinel file was created");
+  });
+
+  it("should not execute injected commands via backticks with .py extension", async () => {
+    const maliciousPath = "`echo INJECTED > " + SENTINEL + "`.py";
+    try {
+      await runStaticAnalysis({ rootDir: FIXTURE, targetPath: maliciousPath });
+    } catch {
+      // errors are acceptable – injection must not succeed
+    }
+
+    let injected = false;
+    try {
+      await readFile(SENTINEL, "utf-8");
+      injected = true;
+    } catch {
+      injected = false;
+    }
+    assert.strictEqual(injected, false, "Command injection via backticks succeeded – sentinel file was created");
+  });
+
+  it("should not execute injected commands via semicolon ending with .py", async () => {
+    // Craft: foo; echo INJECTED > sentinel; echo.py
+    const maliciousPath = `foo; echo INJECTED > ${SENTINEL}; echo.py`;
+    try {
+      await runStaticAnalysis({ rootDir: FIXTURE, targetPath: maliciousPath });
+    } catch {
+      // errors are acceptable – injection must not succeed
+    }
+
+    let injected = false;
+    try {
+      await readFile(SENTINEL, "utf-8");
+      injected = true;
+    } catch {
+      injected = false;
+    }
+    assert.strictEqual(injected, false, "Command injection via semicolon succeeded – sentinel file was created");
+  });
+
+  it("should not execute injected commands via pipe ending with .py", async () => {
+    const maliciousPath = `safe.py | tee ${SENTINEL} | cat foo.py`;
+    try {
+      await runStaticAnalysis({ rootDir: FIXTURE, targetPath: maliciousPath });
+    } catch {
+      // errors are acceptable – injection must not succeed
+    }
+
+    let injected = false;
+    try {
+      await readFile(SENTINEL, "utf-8");
+      injected = true;
+    } catch {
+      injected = false;
+    }
+    assert.strictEqual(injected, false, "Command injection via pipe succeeded – sentinel file was created");
+  });
+});


### PR DESCRIPTION
## Vulnerability Summary

**CWE-78: Improper Neutralization of Special Elements used in an OS Command (Command Injection)**
**Severity: High (local context)**

### Data Flow

1. The MCP tool `run_static_analysis` accepts a `target_path` parameter (`z.string().optional()`) from the calling agent.
2. `src/index.ts` (lines ~297–306) passes `target_path` directly into `runStaticAnalysis({ rootDir: ROOT_DIR, targetPath: target_path })` with no sanitization.
3. In `src/tools/static-analysis.ts`, the `targetPath` is resolved via `resolve(rootDir, targetPath)` (which preserves shell metacharacters) and appended to a linter command's `args` array.
4. **Before this fix**, `runCommand()` concatenated `cmd` and `args` into a single string (`const fullCmd = \`${cmd} ${args.join(" ")}\``) and executed it with `child_process.exec()`, which spawns a shell.
5. Shell metacharacters in `targetPath` (e.g., `$()`, backticks, `;`, `|`) were interpreted by the shell, enabling arbitrary command execution.

### Proof of Exploitability

A benign proof was performed locally during the review process:
- Payload: `$(echo INJECTED > /tmp/cp_rce_proof).py`
- Command executed: `python -m py_compile /tmp/$(echo INJECTED > /tmp/cp_rce_proof).py`
- Result: The sentinel file `/tmp/cp_rce_proof` was created containing "INJECTED", confirming shell expansion occurred.

### Realistic Impact

- Arbitrary command execution with the developer's local permissions
- Possible local data theft, persistence, or toolchain tampering
- Exploitable by a malicious or prompt-injected agent issuing a crafted `run_static_analysis` tool call

---

## Fix Description

**Single change in `src/tools/static-analysis.ts`:**

| Before (vulnerable) | After (fixed) |
|---|---|
| `import { exec } from "child_process"` | `import { execFile } from "child_process"` |
| `const execAsync = promisify(exec)` | `const execFileAsync = promisify(execFile)` |
| `const fullCmd = \`${cmd} ${args.join(" ")}\`` | *(removed)* |
| `execAsync(fullCmd, { cwd, ... })` | `execFileAsync(cmd, args, { cwd, ... })` |

### Rationale

`child_process.execFile` does **not** spawn a shell. The command and its arguments are passed directly to the OS `execvp` syscall, so shell metacharacters in any argument are treated as literal filename characters — not as shell syntax. This is the standard Node.js mitigation for CWE-78 when shell features are not needed.

No `shell: true` option is set. The functional behavior (running linters with arguments) is preserved identically.

---

## Test Results

New test file: `test/main/static-analysis-injection.test.mjs` (102 lines, 4 test cases)

| Test | Payload | Result |
|---|---|---|
| `$()` injection with `.py` extension | `$(echo INJECTED > sentinel).py` | ✅ Pass — no sentinel file created |
| Backtick injection with `.py` extension | `` \`echo INJECTED > sentinel\`.py `` | ✅ Pass — no sentinel file created |
| Semicolon injection ending with `.py` | `foo; echo INJECTED > sentinel; echo.py` | ✅ Pass — no sentinel file created |
| Pipe injection ending with `.py` | `safe.py \| tee sentinel \| cat foo.py` | ✅ Pass — no sentinel file created |

Each test calls `runStaticAnalysis()` with a malicious `targetPath` and asserts that a sentinel file was **not** created, confirming shell metacharacters are no longer interpreted.

---

## Disprove Analysis (Stage 4 — Adversarial Self-Review)

We systematically attempted to invalidate this finding:

### Deployment & Exposure
- **Network check:** Server uses `StdioServerTransport` (stdio), not HTTP. No Docker/k8s/CORS configs found. Not internet-facing by default.
- **Deployment model:** README documents local IDE/agent integration via `npx`/`bunx` in Claude/Cursor/VS Code/Windsurf/OpenCode configurations.
- **Conclusion:** Exposure is limited to **local tool users and prompt-injected agents**, which is the standard MCP threat model.

### Authentication & Validation
- **Auth check:** No authentication gate on the `run_static_analysis` tool handler. `src/index.ts` passes `target_path` straight through.
- **Input validation:** No `sanitize`, `validate`, `escape`, `clean`, `whitelist`, or `allowlist` logic found in `src/tools/static-analysis.ts`.
- **Path resolution:** `resolve("/tmp/root", "$(echo INJECTED > /tmp/pwned).py")` returns `/tmp/root/$(echo INJECTED > /tmp/pwned).py` — metacharacters are preserved.

### Prior Art & Duplicates
- No prior security issues found in the repository (`gh issue list --search "security OR CVE OR vulnerability"` returned empty).
- No `SECURITY.md` or `.github/SECURITY.md` found.
- No prior fix for this issue found in main branch history.

### Fix Adequacy
- After fix: `grep` confirms no remaining `exec` (only `execFile`), and no `shell: true` anywhere in the static analysis code path.
- No equivalent parallel RCE path found for this code path in the repository.
- Other `child_process` usages in the repo are test utilities using `execFile`/`spawn` (not the same shell-injection pattern).

### Verdict

**CONFIRMED_VALID** — Confidence: **High**

The finding is real, the fix is appropriate, and no disproving evidence was found. Severity is best described as **local/high-impact** rather than internet-facing, consistent with the MCP local-agent threat model.

---

## Diff Summary

```
 src/tools/static-analysis.ts                 |   7 +-
 test/main/static-analysis-injection.test.mjs | 102 ++++++++++++++++++
 2 files changed, 105 insertions(+), 4 deletions(-)
```

Minimal, focused change — only the affected file and new regression tests. No unrelated modifications.