### PR TITLE
fix: correct path containment check for Windows separators

### DIFF
--- a/src/git/shadow.ts
+++ b/src/git/shadow.ts
@@ -3,7 +3,7 @@
 
 import { simpleGit, type SimpleGit } from "simple-git";
 import { readFile, writeFile, mkdir } from "fs/promises";
-import { join, dirname, resolve } from "path";
+import { dirname, isAbsolute, join, relative, resolve, sep } from "path";
 
 const SHADOW_BRANCH = "mcp-shadow-history";
 const DATA_DIR = ".mcp_data";
@@ -16,9 +16,10 @@ export interface RestorePoint {
 }
 
 function assertWithinRoot(rootDir: string, filePath: string): string {
-  const resolved = resolve(rootDir, filePath);
-  const normalizedRoot = resolve(rootDir) + "/";
-  if (!resolved.startsWith(normalizedRoot) && resolved !== resolve(rootDir)) {
+  const root = resolve(rootDir);
+  const resolved = resolve(root, filePath);
+  const rel = relative(root, resolved);
+  if (rel === ".." || rel.startsWith(".." + sep) || isAbsolute(rel)) {
     throw new Error(`Path traversal denied: "${filePath}" resolves outside root directory`);
   }
   return resolved;

--- a/test/main/walker.test.mjs
+++ b/test/main/walker.test.mjs
@@ -6,6 +6,16 @@ import { join } from "path";
 
 const FIXTURE_DIR = join(process.cwd(), "test", "_walk_fixtures");
 
+async function trySymlink(symlink, target, path) {
+  try {
+    await symlink(target, path);
+    return true;
+  } catch (error) {
+    if (error.code === "EPERM" || error.code === "EACCES") return false;
+    throw error;
+  }
+}
+
 describe("walker", () => {
   before(async () => {
     await rm(FIXTURE_DIR, { recursive: true, force: true });
@@ -345,7 +355,7 @@ describe("walker", () => {
       );
     });
 
-    it("rejects symlinked extraRoots that point outside the workspace", async () => {
+    it("rejects symlinked extraRoots that point outside the workspace", async (t) => {
       const { walkRoots } = await import("../../build/core/walker.js");
       const { symlink, mkdir, rm, writeFile } = await import("fs/promises");
       const SYM = join(FIXTURE_DIR, "_sym");
@@ -356,7 +366,9 @@ describe("walker", () => {
       await mkdir(EXTERNAL, { recursive: true });
       await writeFile(join(EXTERNAL, "secret.txt"), "secret");
       // Place a symlink INSIDE the workspace pointing OUTSIDE.
-      await symlink(EXTERNAL, join(SYM, "link"));
+      if (!(await trySymlink(symlink, EXTERNAL, join(SYM, "link")))) {
+        return t.skip("symlink creation not permitted in this environment");
+      }
 
       await assert.rejects(
         () => walkRoots({ rootDir: SYM, extraRoots: ["link"] }),
@@ -367,7 +379,7 @@ describe("walker", () => {
       await rm(EXTERNAL, { recursive: true, force: true });
     });
 
-    it("follows symlinked extraRoots that point inside the workspace", async () => {
+    it("follows symlinked extraRoots that point inside the workspace", async (t) => {
       const { walkRoots } = await import("../../build/core/walker.js");
       const { symlink, mkdir, rm, writeFile } = await import("fs/promises");
       const SYM = join(FIXTURE_DIR, "_sym_inside");
@@ -375,7 +387,9 @@ describe("walker", () => {
       await mkdir(join(SYM, "real"), { recursive: true });
       await writeFile(join(SYM, "real", "ok.txt"), "ok");
       await writeFile(join(SYM, ".gitignore"), "linked/\n");  // exclude symlink-named path from primary walk so the only way to see ok.txt is via the extraRoot
-      await symlink(join(SYM, "real"), join(SYM, "linked"));
+      if (!(await trySymlink(symlink, join(SYM, "real"), join(SYM, "linked")))) {
+        return t.skip("symlink creation not permitted in this environment");
+      }
 
       const entries = await walkRoots({ rootDir: SYM, extraRoots: ["linked"] });
       const paths = entries.map((e) => e.relativePath);


### PR DESCRIPTION
Fixes a Windows-only path bug that made three tools unusable and broke 15 tests on Windows.

## Problem

`assertWithinRoot` in `src/git/shadow.ts` guarded against path traversal by comparing:

```ts
const resolved = resolve(rootDir, filePath);          // native separators
const normalizedRoot = resolve(rootDir) + "/";        // hardcoded forward slash
if (!resolved.startsWith(normalizedRoot) && resolved !== resolve(rootDir)) { ... }
```

On Windows `resolve()` returns backslash paths (`C:\repo\valid.ts`), but the root is suffixed with a forward slash (`C:\repo/`). `startsWith` therefore never matched, so **every in-root path was rejected** as `Path traversal denied: "valid.ts" resolves outside root directory`.

That made `createRestorePoint`, `restorePoint`, and (through it) `proposeCommit` throw on any real file on Windows, and caused 15 failures across the `shadow` and `propose-commit` suites.

## Fix

Replace the string-prefix comparison with a separator-agnostic containment test using `path.relative`:

```ts
const root = resolve(rootDir);
const resolved = resolve(root, filePath);
const rel = relative(root, resolved);
if (rel === ".." || rel.startsWith(".." + sep) || isAbsolute(rel)) {
  throw new Error(`Path traversal denied: ...`);
}
```

A path is outside the root only when the relative path escapes with `..` or is absolute (a different Windows drive). This behaves identically on POSIX and Windows, and still rejects genuine traversal.

## Tests

- The existing traversal-rejection tests (`restorePoint rejects traversal paths in manifest`, `shadow path traversal (CWE-22)`, `does not write files outside rootDir during restore`) still pass, so the security guarantee is intact.
- The two `walkRoots` symlink tests now skip gracefully via a `trySymlink` helper when the OS denies symlink creation (EPERM/EACCES, e.g. Windows without developer mode). They run in full on POSIX/CI.

### Results (Windows, local)

| | before | after |
|---|---|---|
| pass | 219 | 234 |
| fail | 17 | 0 |
| skipped | 0 | 2 |

`tsc` compiles clean. No production behavior change on POSIX; the security check is unchanged there.